### PR TITLE
check if ../data exists first

### DIFF
--- a/MuxLink/DMUX_Locking/convert_DMUX.py
+++ b/MuxLink/DMUX_Locking/convert_DMUX.py
@@ -15,7 +15,9 @@ key_size=int(sys.argv[2])
 location=sys.argv[3]
 print("Benchmark is "+benchmark)
 print("Key-size is "+str(key_size))
-os.mkdir("../data")
+if not os.path.exists("../data"):
+    os.mkdir("../data")
+
 
 def GenerateKey(K):
     nums= np.ones(K)


### PR DESCRIPTION
The attack only runs the first time when it creates ../data. After that it crushes saying ../data exists.